### PR TITLE
Improve tests

### DIFF
--- a/CoreDataQueryInterface.xcodeproj/project.pbxproj
+++ b/CoreDataQueryInterface.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		8E4918D71CAF432100DFB3C8 /* TestEntityAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4918D51CAF432100DFB3C8 /* TestEntityAttribute.swift */; };
 		8E4918E51CAF71BC00DFB3C8 /* StringAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4918DE1CAF6F1200DFB3C8 /* StringAttribute.swift */; };
 		8E4918E61CAF71BD00DFB3C8 /* StringAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4918DE1CAF6F1200DFB3C8 /* StringAttribute.swift */; };
+		8E4918EA1CB35F1E00DFB3C8 /* ManagedObjectContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4918E91CB35F1E00DFB3C8 /* ManagedObjectContextTests.swift */; };
+		8E4918EB1CB35F1E00DFB3C8 /* ManagedObjectContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4918E91CB35F1E00DFB3C8 /* ManagedObjectContextTests.swift */; };
 		8EC22BBF1CAA37D500642BB6 /* TypedExpressionConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EC22BBE1CAA37D500642BB6 /* TypedExpressionConvertible.swift */; };
 		8EC22BC11CAA3AE400642BB6 /* TypedExpressionConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EC22BBE1CAA37D500642BB6 /* TypedExpressionConvertible.swift */; };
 		F30C0B7C1B37A20A00D8D762 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30C0B7B1B37A20A00D8D762 /* Util.swift */; };
@@ -140,6 +142,7 @@
 		8E4918D01CAF41B100DFB3C8 /* TestEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEntity.swift; sourceTree = "<group>"; };
 		8E4918D51CAF432100DFB3C8 /* TestEntityAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEntityAttribute.swift; sourceTree = "<group>"; };
 		8E4918DE1CAF6F1200DFB3C8 /* StringAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = StringAttribute.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		8E4918E91CB35F1E00DFB3C8 /* ManagedObjectContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManagedObjectContextTests.swift; sourceTree = "<group>"; };
 		8EC22BBE1CAA37D500642BB6 /* TypedExpressionConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = TypedExpressionConvertible.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		F30C0B7B1B37A20A00D8D762 /* Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
 		F30D1CCA1B2A891100AF80A1 /* CoreDataQueryInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreDataQueryInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -238,6 +241,7 @@
 				8E49189F1CACE93600DFB3C8 /* NumericTypeTests.swift */,
 				F3E6B5521B2C01CC00F735EE /* OrderTests.swift */,
 				F33567641B2D2EF7007853DB /* SelectionAndGroupingTests.swift */,
+				8E4918E91CB35F1E00DFB3C8 /* ManagedObjectContextTests.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -562,6 +566,7 @@
 			files = (
 				F33567681B2D2EF7007853DB /* SelectionAndGroupingTests.swift in Sources */,
 				F3E6B5541B2C01CC00F735EE /* OrderTests.swift in Sources */,
+				8E4918EB1CB35F1E00DFB3C8 /* ManagedObjectContextTests.swift in Sources */,
 				F31C642A1B696CD900235764 /* NSManagedObjectContextExtensions.swift in Sources */,
 				8E4918D71CAF432100DFB3C8 /* TestEntityAttribute.swift in Sources */,
 				8E4918A11CACE93600DFB3C8 /* NumericTypeTests.swift in Sources */,
@@ -635,6 +640,7 @@
 				8E4918C71CAE0A9300DFB3C8 /* EmployeeAttribute.swift in Sources */,
 				F30C0B7C1B37A20A00D8D762 /* Util.swift in Sources */,
 				F3251A121B2BDE6E0031B817 /* Employee.swift in Sources */,
+				8E4918EA1CB35F1E00DFB3C8 /* ManagedObjectContextTests.swift in Sources */,
 				F3E6B5501B2BFCA500F735EE /* FilterTests.swift in Sources */,
 				F37C46B21B2A780200B35B1B /* SanityTests.swift in Sources */,
 				8E4918D61CAF432100DFB3C8 /* TestEntityAttribute.swift in Sources */,

--- a/CoreDataQueryInterface.xcodeproj/xcshareddata/xcschemes/CoreDataQueryInterface iOS.xcscheme
+++ b/CoreDataQueryInterface.xcodeproj/xcshareddata/xcschemes/CoreDataQueryInterface iOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/CoreDataQueryInterface/Operators.swift
+++ b/CoreDataQueryInterface/Operators.swift
@@ -36,15 +36,7 @@ public func ><L: TypedExpressionConvertible, R: TypedExpressionConvertible where
     return lhs.greaterThan(rhs)
 }
 
-public func ><L: TypedExpressionConvertible where L.ExpressionValueType: ComparableExpression>(lhs: L, rhs: Null) -> NSPredicate {
-    return lhs.greaterThan(rhs)
-}
-
 public func >=<L: TypedExpressionConvertible, R: TypedExpressionConvertible where L.ExpressionValueType == R.ExpressionValueType, L.ExpressionValueType: ComparableExpression>(lhs: L, rhs: R) -> NSPredicate {
-    return lhs.greaterThanOrEqualTo(rhs)
-}
-
-public func >=<L: TypedExpressionConvertible where L.ExpressionValueType: ComparableExpression>(lhs: L, rhs: Null) -> NSPredicate {
     return lhs.greaterThanOrEqualTo(rhs)
 }
 

--- a/CoreDataQueryInterface/TypedExpressionConvertible.swift
+++ b/CoreDataQueryInterface/TypedExpressionConvertible.swift
@@ -45,32 +45,16 @@ extension TypedExpressionConvertible where ExpressionValueType: ComparableExpres
         return PredicateBuilder.greaterThan(lhs: self, rhs: rhs, options: options)
     }
     
-    public func greaterThan(rhs: Null) -> NSPredicate {
-        return PredicateBuilder.greaterThan(lhs: self, rhs: rhs)
-    }
-    
     public func greaterThanOrEqualTo<R: TypedExpressionConvertible where Self.ExpressionValueType == R.ExpressionValueType>(rhs: R, options: NSComparisonPredicateOptions = []) -> NSPredicate {
         return PredicateBuilder.greaterThanOrEqualTo(lhs: self, rhs: rhs, options: options)
-    }
-    
-    public func greaterThanOrEqualTo(rhs: Null) -> NSPredicate {
-        return PredicateBuilder.greaterThanOrEqualTo(lhs: self, rhs: rhs)
     }
     
     public func lessThan<R: TypedExpressionConvertible where Self.ExpressionValueType == R.ExpressionValueType>(rhs: R, options: NSComparisonPredicateOptions = []) -> NSPredicate {
         return PredicateBuilder.lessThan(lhs: self, rhs: rhs, options: options)
     }
 
-    public func lessThan(rhs: Null) -> NSPredicate {
-        return PredicateBuilder.lessThan(lhs: self, rhs: rhs)
-    }
-
     public func lessThanOrEqualTo<R: TypedExpressionConvertible where Self.ExpressionValueType == R.ExpressionValueType>(rhs: R, options: NSComparisonPredicateOptions = []) -> NSPredicate {
         return PredicateBuilder.lessThanOrEqualTo(lhs: self, rhs: rhs, options: options)
-    }
-
-    public func lessThanOrEqualTo(rhs: Null) -> NSPredicate {
-        return PredicateBuilder.lessThanOrEqualTo(lhs: self, rhs: rhs)
     }
     
     public func between<R: TypedExpressionConvertible where Self.ExpressionValueType == R.ExpressionValueType>(start: R, and end: R, options: NSComparisonPredicateOptions = []) -> NSPredicate {

--- a/CoreDataQueryInterfaceTests/BaseTestCase.swift
+++ b/CoreDataQueryInterfaceTests/BaseTestCase.swift
@@ -14,6 +14,8 @@ class BaseTestCase: XCTestCase {
     
     private static var managedObjectContext: NSManagedObjectContext!
     
+    static var managedObjectModel: NSManagedObjectModel = NSManagedObjectModel.mergedModelFromBundles(NSBundle.allBundles())!
+    
     var managedObjectContext: NSManagedObjectContext {
         return BaseTestCase.managedObjectContext
     }
@@ -30,8 +32,7 @@ class BaseTestCase: XCTestCase {
             let url = NSURL(fileURLWithPath: path)
 
             // Create the database
-            let model = NSManagedObjectModel.mergedModelFromBundles(NSBundle.allBundles())!
-            let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+            let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: self.managedObjectModel)
             try! persistentStoreCoordinator.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: url, options: nil)
             let managedObjectContext = NSManagedObjectContext(concurrencyType: .MainQueueConcurrencyType)
             managedObjectContext.persistentStoreCoordinator = persistentStoreCoordinator

--- a/CoreDataQueryInterfaceTests/FilterTests.swift
+++ b/CoreDataQueryInterfaceTests/FilterTests.swift
@@ -26,6 +26,16 @@ class FilterTests : BaseTestCase {
         XCTAssertEqual(nickNameLessCount, 10)
     }
     
+    func testCountEmployeesWithNickName() {
+        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.lastName != "Jones" }).count()
+        XCTAssertEqual(nickNameLessCount, 20)
+    }
+    
+    func testEmployeesWithNickName() {
+        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.nickName != nil }).count()
+        XCTAssertEqual(nickNameLessCount, 15)
+    }
+    
     func testCountEmployeesNameNotMortonOrJones() {
         let names = ["Morton", "Jones"]
         let notMortonOrJonesCount = managedObjectContext.from(Employee).filter({ $0.lastName != names }).count()
@@ -55,6 +65,26 @@ class FilterTests : BaseTestCase {
             }.count > 0
         }.count()
         XCTAssertEqual(departmentCount, 2)
+    }
+    
+    func testCountEmployeesWithFirstNameBeginningWithL () {
+        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName.beginsWith("L") }).count()
+        XCTAssertEqual(nickNameLessCount, 5)
+    }
+    
+    func testCountEmployeesWithFirstNameEndingWithA () {
+        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName.endsWith("a") }).count()
+        XCTAssertEqual(nickNameLessCount, 10)
+    }
+    
+    func testCountEmployeesWithFirstNameOrLastName () {
+        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" || employee.lastName == "Jones" }).count()
+        XCTAssertEqual(nickNameLessCount, 9)
+    }
+    
+    func testCountEmployeesWithFirstNameAndLastName () {
+        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" && employee.lastName == "Jones" }).count()
+        XCTAssertEqual(nickNameLessCount, 1)
     }
     
     func testDepartmentsWithNameMatchingRegex() {

--- a/CoreDataQueryInterfaceTests/FilterTests.swift
+++ b/CoreDataQueryInterfaceTests/FilterTests.swift
@@ -42,6 +42,11 @@ class FilterTests : BaseTestCase {
         XCTAssertEqual(notMortonOrJonesCount, 15)
     }
     
+    func testCountEmployeesWithNameLike() {
+        let count = try! managedObjectContext.from(Employee).filter({ $0.lastName.like("*nes") }).count()
+        XCTAssertEqual(count, 5)
+    }
+    
     func testEmptyKeyRepresentsSelf() {
         let employeeQuery = managedObjectContext.from(Employee)
         let firstObjectID = employeeQuery.objectIDs().first()!
@@ -58,33 +63,52 @@ class FilterTests : BaseTestCase {
         XCTAssertEqual(highSalaryCount, 8)
     }
     
+    func testEmployeesWithLessThanOrEqualToSalary() {
+        let salary = 80000
+        let e = EmployeeAttribute()
+        let highSalaryCount = try! managedObjectContext.from(Employee).filter(e.salary <= salary).count()
+        XCTAssertEqual(highSalaryCount, 17)
+    }
+    
     func testNumberOfDepartmentsWithEmployeesWhoseLastNamesStartWithSUsingSubquery() {
-        let departmentCount = managedObjectContext.from(Department).filter{ department in
-            department.employees.subquery("$e") {
+        let departmentCount = try! managedObjectContext.from(Department).filter{ department in
+            department.employees.subquery {
                 some($0.lastName.beginsWith("S", options: .CaseInsensitivePredicateOption))
             }.count > 0
         }.count()
         XCTAssertEqual(departmentCount, 2)
     }
     
+    func testNumberOfDepartmentsWithNoSalariesLessThan() {
+        let departmentCount = try! managedObjectContext.from(Department).filter {
+                none($0.employees.salary <= 50000)
+            }.count()
+        XCTAssertEqual(departmentCount, 3)
+    }
+    
     func testCountEmployeesWithFirstNameBeginningWithL () {
-        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName.beginsWith("L") }).count()
-        XCTAssertEqual(nickNameLessCount, 5)
+        let count = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName.beginsWith("L") }).count()
+        XCTAssertEqual(count, 5)
     }
     
     func testCountEmployeesWithFirstNameEndingWithA () {
-        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName.endsWith("a") }).count()
-        XCTAssertEqual(nickNameLessCount, 10)
+        let count = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName.endsWith("a") }).count()
+        XCTAssertEqual(count, 10)
     }
     
     func testCountEmployeesWithFirstNameOrLastName () {
-        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" || employee.lastName == "Jones" }).count()
-        XCTAssertEqual(nickNameLessCount, 9)
+        let firstOrLastNameCount = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" || employee.lastName == "Jones" }).count()
+        XCTAssertEqual(firstOrLastNameCount, 9)
     }
     
     func testCountEmployeesWithFirstNameAndLastName () {
-        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" && employee.lastName == "Jones" }).count()
-        XCTAssertEqual(nickNameLessCount, 1)
+        let count = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" && employee.lastName == "Jones" }).count()
+        XCTAssertEqual(count, 1)
+    }
+    
+    func testEmployeesWithFirstNameContaining () {
+        let count = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName.contains("an")}).count()
+        XCTAssertEqual(count, 10)
     }
     
     func testDepartmentsWithNameMatchingRegex() {

--- a/CoreDataQueryInterfaceTests/FilterTests.swift
+++ b/CoreDataQueryInterfaceTests/FilterTests.swift
@@ -27,12 +27,12 @@ class FilterTests : BaseTestCase {
     }
     
     func testCountEmployeesWithNickName() {
-        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.lastName != "Jones" }).count()
+        let nickNameLessCount =  managedObjectContext.from(Employee).filter({ employee in employee.lastName != "Jones" }).count()
         XCTAssertEqual(nickNameLessCount, 20)
     }
     
     func testEmployeesWithNickName() {
-        let nickNameLessCount = try! managedObjectContext.from(Employee).filter({ employee in employee.nickName != nil }).count()
+        let nickNameLessCount =  managedObjectContext.from(Employee).filter({ employee in employee.nickName != nil }).count()
         XCTAssertEqual(nickNameLessCount, 15)
     }
     
@@ -43,7 +43,7 @@ class FilterTests : BaseTestCase {
     }
     
     func testCountEmployeesWithNameLike() {
-        let count = try! managedObjectContext.from(Employee).filter({ $0.lastName.like("*nes") }).count()
+        let count =  managedObjectContext.from(Employee).filter({ $0.lastName.like("*nes") }).count()
         XCTAssertEqual(count, 5)
     }
     
@@ -66,12 +66,12 @@ class FilterTests : BaseTestCase {
     func testEmployeesWithLessThanOrEqualToSalary() {
         let salary = 80000
         let e = EmployeeAttribute()
-        let highSalaryCount = try! managedObjectContext.from(Employee).filter(e.salary <= salary).count()
+        let highSalaryCount =  managedObjectContext.from(Employee).filter(e.salary <= salary).count()
         XCTAssertEqual(highSalaryCount, 17)
     }
     
     func testNumberOfDepartmentsWithEmployeesWhoseLastNamesStartWithSUsingSubquery() {
-        let departmentCount = try! managedObjectContext.from(Department).filter{ department in
+        let departmentCount =  managedObjectContext.from(Department).filter{ department in
             department.employees.subquery {
                 some($0.lastName.beginsWith("S", options: .CaseInsensitivePredicateOption))
             }.count > 0
@@ -80,34 +80,34 @@ class FilterTests : BaseTestCase {
     }
     
     func testNumberOfDepartmentsWithNoSalariesLessThan() {
-        let departmentCount = try! managedObjectContext.from(Department).filter {
+        let departmentCount =  managedObjectContext.from(Department).filter {
                 none($0.employees.salary <= 50000)
             }.count()
         XCTAssertEqual(departmentCount, 3)
     }
     
     func testCountEmployeesWithFirstNameBeginningWithL () {
-        let count = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName.beginsWith("L") }).count()
+        let count =  managedObjectContext.from(Employee).filter({ employee in employee.firstName.beginsWith("L") }).count()
         XCTAssertEqual(count, 5)
     }
     
     func testCountEmployeesWithFirstNameEndingWithA () {
-        let count = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName.endsWith("a") }).count()
+        let count =  managedObjectContext.from(Employee).filter({ employee in employee.firstName.endsWith("a") }).count()
         XCTAssertEqual(count, 10)
     }
     
     func testCountEmployeesWithFirstNameOrLastName () {
-        let firstOrLastNameCount = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" || employee.lastName == "Jones" }).count()
+        let firstOrLastNameCount =  managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" || employee.lastName == "Jones" }).count()
         XCTAssertEqual(firstOrLastNameCount, 9)
     }
     
     func testCountEmployeesWithFirstNameAndLastName () {
-        let count = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" && employee.lastName == "Jones" }).count()
+        let count =  managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" && employee.lastName == "Jones" }).count()
         XCTAssertEqual(count, 1)
     }
     
     func testEmployeesWithFirstNameContaining () {
-        let count = try! managedObjectContext.from(Employee).filter({ employee in employee.firstName.contains("an")}).count()
+        let count =  managedObjectContext.from(Employee).filter({ employee in employee.firstName.contains("an")}).count()
         XCTAssertEqual(count, 10)
     }
     

--- a/CoreDataQueryInterfaceTests/FilterTests.swift
+++ b/CoreDataQueryInterfaceTests/FilterTests.swift
@@ -27,12 +27,12 @@ class FilterTests : BaseTestCase {
     }
     
     func testCountEmployeesWithNickName() {
-        let nickNameLessCount =  managedObjectContext.from(Employee).filter({ employee in employee.lastName != "Jones" }).count()
+        let nickNameLessCount = managedObjectContext.from(Employee).filter({ employee in employee.lastName != "Jones" }).count()
         XCTAssertEqual(nickNameLessCount, 20)
     }
     
     func testEmployeesWithNickName() {
-        let nickNameLessCount =  managedObjectContext.from(Employee).filter({ employee in employee.nickName != nil }).count()
+        let nickNameLessCount = managedObjectContext.from(Employee).filter({ employee in employee.nickName != nil }).count()
         XCTAssertEqual(nickNameLessCount, 15)
     }
     
@@ -43,7 +43,7 @@ class FilterTests : BaseTestCase {
     }
     
     func testCountEmployeesWithNameLike() {
-        let count =  managedObjectContext.from(Employee).filter({ $0.lastName.like("*nes") }).count()
+        let count = managedObjectContext.from(Employee).filter({ $0.lastName.like("*nes") }).count()
         XCTAssertEqual(count, 5)
     }
     
@@ -66,12 +66,12 @@ class FilterTests : BaseTestCase {
     func testEmployeesWithLessThanOrEqualToSalary() {
         let salary = 80000
         let e = EmployeeAttribute()
-        let highSalaryCount =  managedObjectContext.from(Employee).filter(e.salary <= salary).count()
+        let highSalaryCount = managedObjectContext.from(Employee).filter(e.salary <= salary).count()
         XCTAssertEqual(highSalaryCount, 17)
     }
     
     func testNumberOfDepartmentsWithEmployeesWhoseLastNamesStartWithSUsingSubquery() {
-        let departmentCount =  managedObjectContext.from(Department).filter{ department in
+        let departmentCount = managedObjectContext.from(Department).filter{ department in
             department.employees.subquery {
                 some($0.lastName.beginsWith("S", options: .CaseInsensitivePredicateOption))
             }.count > 0
@@ -80,34 +80,34 @@ class FilterTests : BaseTestCase {
     }
     
     func testNumberOfDepartmentsWithNoSalariesLessThan() {
-        let departmentCount =  managedObjectContext.from(Department).filter {
+        let departmentCount = managedObjectContext.from(Department).filter {
                 none($0.employees.salary <= 50000)
             }.count()
         XCTAssertEqual(departmentCount, 3)
     }
     
     func testCountEmployeesWithFirstNameBeginningWithL () {
-        let count =  managedObjectContext.from(Employee).filter({ employee in employee.firstName.beginsWith("L") }).count()
+        let count = managedObjectContext.from(Employee).filter({ employee in employee.firstName.beginsWith("L") }).count()
         XCTAssertEqual(count, 5)
     }
     
     func testCountEmployeesWithFirstNameEndingWithA () {
-        let count =  managedObjectContext.from(Employee).filter({ employee in employee.firstName.endsWith("a") }).count()
+        let count = managedObjectContext.from(Employee).filter({ employee in employee.firstName.endsWith("a") }).count()
         XCTAssertEqual(count, 10)
     }
     
     func testCountEmployeesWithFirstNameOrLastName () {
-        let firstOrLastNameCount =  managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" || employee.lastName == "Jones" }).count()
+        let firstOrLastNameCount = managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" || employee.lastName == "Jones" }).count()
         XCTAssertEqual(firstOrLastNameCount, 9)
     }
     
     func testCountEmployeesWithFirstNameAndLastName () {
-        let count =  managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" && employee.lastName == "Jones" }).count()
+        let count = managedObjectContext.from(Employee).filter({ employee in employee.firstName == "Isabella" && employee.lastName == "Jones" }).count()
         XCTAssertEqual(count, 1)
     }
     
     func testEmployeesWithFirstNameContaining () {
-        let count =  managedObjectContext.from(Employee).filter({ employee in employee.firstName.contains("an")}).count()
+        let count = managedObjectContext.from(Employee).filter({ employee in employee.firstName.contains("an")}).count()
         XCTAssertEqual(count, 10)
     }
     

--- a/CoreDataQueryInterfaceTests/FilterTests.swift
+++ b/CoreDataQueryInterfaceTests/FilterTests.swift
@@ -79,11 +79,18 @@ class FilterTests : BaseTestCase {
         XCTAssertEqual(departmentCount, 2)
     }
     
-    func testNumberOfDepartmentsWithNoSalariesLessThan() {
+    func testNumberOfDepartmentsWithNoSalariesLessThanOrEqualTo() {
         let departmentCount = managedObjectContext.from(Department).filter {
                 none($0.employees.salary <= 50000)
             }.count()
         XCTAssertEqual(departmentCount, 3)
+    }
+    
+    func testNumberOfDepartmentsWithAnySalariesLessThan() {
+        let departmentCount = managedObjectContext.from(Department).filter {
+            any($0.employees.salary < 40000)
+            }.count()
+        XCTAssertEqual(departmentCount, 1)
     }
     
     func testCountEmployeesWithFirstNameBeginningWithL () {

--- a/CoreDataQueryInterfaceTests/ManagedObjectContextTests.swift
+++ b/CoreDataQueryInterfaceTests/ManagedObjectContextTests.swift
@@ -20,12 +20,17 @@ class ManagedObjectContextTests: BaseTestCase {
     func testRequestWithMOC() {
         let request = EntityQuery.from(Employee).request(managedObjectContext)
         let employees = try! managedObjectContext.executeFetchRequest(request)
-        XCTAssert(employees.count == 25)
+        XCTAssertEqual(employees.count, 25)
+    }
+    
+    func testCountWithMOC() {
+        let departmentCount = EntityQuery.from(Department).count(managedObjectContext)
+        XCTAssertEqual(departmentCount, 3)
     }
     
     func testRequestWithModel() {
         let request = EntityQuery.from(Employee).request(BaseTestCase.managedObjectModel)
         let employees = try! managedObjectContext.executeFetchRequest(request)
-        XCTAssert(employees.count == 25)
+        XCTAssertEqual(employees.count, 25)
     }
 }

--- a/CoreDataQueryInterfaceTests/ManagedObjectContextTests.swift
+++ b/CoreDataQueryInterfaceTests/ManagedObjectContextTests.swift
@@ -1,0 +1,31 @@
+//
+//  ManagedObjectContextTests.swift
+//  CoreDataQueryInterface
+//
+//  Created by Patrick Goley on 4/4/16.
+//  Copyright © 2016 Prosumma LLC. All rights reserved.
+//
+
+import XCTest
+import CoreData
+@testable import CoreDataQueryInterface
+
+class ManagedObjectContextTests: BaseTestCase {
+
+    func testNewEntity() {
+        let employee: Employee = managedObjectContext.newEntity()
+        managedObjectContext.deleteObject(employee)
+    }
+    
+    func testRequestWithMOC() {
+        let request = EntityQuery.from(Employee).request(managedObjectContext)
+        let employees = try! managedObjectContext.executeFetchRequest(request)
+        XCTAssert(employees.count == 25)
+    }
+    
+    func testRequestWithModel() {
+        let request = EntityQuery.from(Employee).request(BaseTestCase.managedObjectModel)
+        let employees = try! managedObjectContext.executeFetchRequest(request)
+        XCTAssert(employees.count == 25)
+    }
+}

--- a/CoreDataQueryInterfaceTests/NumericTypeTests.swift
+++ b/CoreDataQueryInterfaceTests/NumericTypeTests.swift
@@ -18,25 +18,25 @@ class NumericTypeTests: BaseTestCase {
     
     func testInt16ValueComparison() {
         let int: Int16 = 32767
-        let resultCount = try! managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
+        let resultCount =  managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
         XCTAssert(resultCount == 1)
     }
     
     func testUInt16ValueComparison() {
         let int: UInt16 = 32767
-        let resultCount = try! managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
+        let resultCount =  managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
         XCTAssert(resultCount == 1)
     }
     
     func testUInt32ValueComparison() {
         let int: UInt32 = 32767
-        let resultCount = try! managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
+        let resultCount =  managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
         XCTAssert(resultCount == 1)
     }
     
     func testUInt64ValueComparison() {
         let int: UInt64 = 32767
-        let resultCount = try! managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
+        let resultCount =  managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
         XCTAssert(resultCount == 1)
     }
     

--- a/CoreDataQueryInterfaceTests/NumericTypeTests.swift
+++ b/CoreDataQueryInterfaceTests/NumericTypeTests.swift
@@ -16,6 +16,12 @@ class NumericTypeTests: BaseTestCase {
         XCTAssert(resultCount == 1)
     }
     
+    func testNSNumberValueComparison() {
+        let intMax = Int.max as NSNumber
+        let resultCount = managedObjectContext.from(TestEntity).filter({ $0.integer64 == intMax }).count()
+        XCTAssert(resultCount == 1)
+    }
+    
     func testInt16ValueComparison() {
         let int: Int16 = 32767
         let resultCount = managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()

--- a/CoreDataQueryInterfaceTests/NumericTypeTests.swift
+++ b/CoreDataQueryInterfaceTests/NumericTypeTests.swift
@@ -18,25 +18,25 @@ class NumericTypeTests: BaseTestCase {
     
     func testInt16ValueComparison() {
         let int: Int16 = 32767
-        let resultCount =  managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
+        let resultCount = managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
         XCTAssert(resultCount == 1)
     }
     
     func testUInt16ValueComparison() {
         let int: UInt16 = 32767
-        let resultCount =  managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
+        let resultCount = managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
         XCTAssert(resultCount == 1)
     }
     
     func testUInt32ValueComparison() {
         let int: UInt32 = 32767
-        let resultCount =  managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
+        let resultCount = managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
         XCTAssert(resultCount == 1)
     }
     
     func testUInt64ValueComparison() {
         let int: UInt64 = 32767
-        let resultCount =  managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
+        let resultCount = managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
         XCTAssert(resultCount == 1)
     }
     

--- a/CoreDataQueryInterfaceTests/NumericTypeTests.swift
+++ b/CoreDataQueryInterfaceTests/NumericTypeTests.swift
@@ -17,7 +17,26 @@ class NumericTypeTests: BaseTestCase {
     }
     
     func testInt16ValueComparison() {
-        let resultCount = managedObjectContext.from(TestEntity).filter({ $0.integer16 == 32767 }).count()
+        let int: Int16 = 32767
+        let resultCount = try! managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
+        XCTAssert(resultCount == 1)
+    }
+    
+    func testUInt16ValueComparison() {
+        let int: UInt16 = 32767
+        let resultCount = try! managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
+        XCTAssert(resultCount == 1)
+    }
+    
+    func testUInt32ValueComparison() {
+        let int: UInt32 = 32767
+        let resultCount = try! managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
+        XCTAssert(resultCount == 1)
+    }
+    
+    func testUInt64ValueComparison() {
+        let int: UInt64 = 32767
+        let resultCount = try! managedObjectContext.from(TestEntity).filter({ $0.integer16 == int }).count()
         XCTAssert(resultCount == 1)
     }
     

--- a/CoreDataQueryInterfaceTests/OrderTests.swift
+++ b/CoreDataQueryInterfaceTests/OrderTests.swift
@@ -36,4 +36,16 @@ class OrderTests : BaseTestCase {
         let secondDepartment = managedObjectContext.from(Department).order(department.name).offset(1).first()!
         XCTAssertEqual(secondDepartment.name, "Engineering")
     }
+    
+    func testMultipleOrderings() {
+        let employees = managedObjectContext.from(Employee).order({employee in [employee.lastName, employee.firstName]}).all()
+        XCTAssertEqual(employees.first!.firstName, "David")
+        XCTAssertEqual(employees.last!.firstName, "Lana")
+    }
+    
+    func testMultipleDescendingOrderings() {
+        let employees = managedObjectContext.from(Employee).order(descending: {employee in [employee.lastName, employee.firstName]}).all()
+        XCTAssertEqual(employees.first!.firstName, "Lana")
+        XCTAssertEqual(employees.last!.firstName, "David")
+    }
 }

--- a/CoreDataQueryInterfaceTests/OrderTests.swift
+++ b/CoreDataQueryInterfaceTests/OrderTests.swift
@@ -30,5 +30,10 @@ class OrderTests : BaseTestCase {
         let departmentName: String = query.reorder().order(department.name).value(department.name)!
         XCTAssertEqual(departmentName, "Accounting")
     }
-
+    
+    func testOffset() {
+        let department = Department.EntityAttributeType()
+        let secondDepartment = try! managedObjectContext.from(Department).order(department.name).offset(1).first()!
+        XCTAssertEqual(secondDepartment.name, "Engineering")
+    }
 }

--- a/CoreDataQueryInterfaceTests/OrderTests.swift
+++ b/CoreDataQueryInterfaceTests/OrderTests.swift
@@ -33,7 +33,7 @@ class OrderTests : BaseTestCase {
     
     func testOffset() {
         let department = Department.EntityAttributeType()
-        let secondDepartment = try! managedObjectContext.from(Department).order(department.name).offset(1).first()!
+        let secondDepartment = managedObjectContext.from(Department).order(department.name).offset(1).first()!
         XCTAssertEqual(secondDepartment.name, "Engineering")
     }
 }

--- a/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
+++ b/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
@@ -72,6 +72,11 @@ class SelectionTests : BaseTestCase {
         XCTAssertEqual(result.count, 5)
     }
     
+    func testClosureAsSelectionProperty() {
+        let result = managedObjectContext.from(Employee).groupBy("lastName").select({employee in [employee.lastName, employee.firstName]}).all()
+        XCTAssertEqual(result.count, 5)
+    }
+    
     func testMultipleGroupByProperty() {
         let result = managedObjectContext.from(Employee).groupBy({[$0.lastName, $0.department]}).select("lastName", "department").all()
         XCTAssertEqual(result.count, 13)

--- a/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
+++ b/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
@@ -57,4 +57,9 @@ class SelectionTests : BaseTestCase {
         let firstName = employees.first!["firstName"]! as! String
         XCTAssertEqual(firstName, "Lana")
     }
+    
+    func testStringAsSelectionProperty() {
+        let result = try! managedObjectContext.from(Employee).groupBy("lastName").select("lastName").all()
+        XCTAssert(result.count == 5)
+    }
 }

--- a/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
+++ b/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
@@ -73,8 +73,8 @@ class SelectionTests : BaseTestCase {
     }
     
     func testClosureAsSelectionProperty() {
-        let result = managedObjectContext.from(Employee).groupBy("lastName").select({employee in [employee.lastName, employee.firstName]}).all()
-        XCTAssertEqual(result.count, 5)
+        let result = managedObjectContext.from(Employee).groupBy("lastName", "department.name").select({employee in [employee.lastName, employee.department.name]}).all()
+        XCTAssertEqual(result.count, 13)
     }
     
     func testMultipleGroupByProperty() {

--- a/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
+++ b/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
@@ -27,6 +27,15 @@ class SelectionTests : BaseTestCase {
         XCTAssertEqual(salaries["Sales"]!, 93000)
     }
     
+    func testMinimumSalaryGroupedByDepartment() {
+        let employee = EmployeeAttribute()
+        let result = try! managedObjectContext.from(Employee).groupBy(employee.department.name).select(employee.department.name, employee.min.salary.named("minSalary")).order(descending: employee.department.name).all()
+        let salaries: [String: Int] = result.toDictionary() { ($0["department.name"]! as! String, ($0["minSalary"]! as! NSNumber).integerValue) }
+        XCTAssertEqual(salaries["Accounting"]!, 32000)
+        XCTAssertEqual(salaries["Engineering"]!, 54000)
+        XCTAssertEqual(salaries["Sales"]!, 62000)
+    }
+    
     func testAverageSalaryGroupedByDepartment() {
         let result = managedObjectContext.from(Employee).groupBy({$0.department.name}).select({$0.department.name}, {$0.average.salary.named("averageSalary")}).order(descending: {$0.department.name}).all()
         let salaries: [String: Int] = result.toDictionary() { ($0["department.name"]! as! String, ($0["averageSalary"]! as! NSNumber).integerValue) }
@@ -60,6 +69,17 @@ class SelectionTests : BaseTestCase {
     
     func testStringAsSelectionProperty() {
         let result = try! managedObjectContext.from(Employee).groupBy("lastName").select("lastName").all()
-        XCTAssert(result.count == 5)
+        XCTAssertEqual(result.count, 5)
+    }
+    
+    func testMultipleGroupByProperty() {
+        let result = try! managedObjectContext.from(Employee).groupBy({[$0.lastName, $0.department]}).select("lastName", "department").all()
+        XCTAssertEqual(result.count, 13)
+    }
+    
+    func testOrderByNSSortDescriptor() {
+        let results = try! managedObjectContext.from(Employee).order(NSSortDescriptor(key: "firstName", ascending: true)).all()
+        XCTAssert(results.first!.firstName == "David" && results.last!.firstName == "Lana")
     }
 }
+

--- a/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
+++ b/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
@@ -29,7 +29,7 @@ class SelectionTests : BaseTestCase {
     
     func testMinimumSalaryGroupedByDepartment() {
         let employee = EmployeeAttribute()
-        let result =  managedObjectContext.from(Employee).groupBy(employee.department.name).select(employee.department.name, employee.min.salary.named("minSalary")).order(descending: employee.department.name).all()
+        let result = managedObjectContext.from(Employee).groupBy(employee.department.name).select(employee.department.name, employee.min.salary.named("minSalary")).order(descending: employee.department.name).all()
         let salaries: [String: Int] = result.toDictionary() { ($0["department.name"]! as! String, ($0["minSalary"]! as! NSNumber).integerValue) }
         XCTAssertEqual(salaries["Accounting"]!, 32000)
         XCTAssertEqual(salaries["Engineering"]!, 54000)
@@ -68,17 +68,17 @@ class SelectionTests : BaseTestCase {
     }
     
     func testStringAsSelectionProperty() {
-        let result =  managedObjectContext.from(Employee).groupBy("lastName").select("lastName").all()
+        let result = managedObjectContext.from(Employee).groupBy("lastName").select("lastName").all()
         XCTAssertEqual(result.count, 5)
     }
     
     func testMultipleGroupByProperty() {
-        let result =  managedObjectContext.from(Employee).groupBy({[$0.lastName, $0.department]}).select("lastName", "department").all()
+        let result = managedObjectContext.from(Employee).groupBy({[$0.lastName, $0.department]}).select("lastName", "department").all()
         XCTAssertEqual(result.count, 13)
     }
     
     func testOrderByNSSortDescriptor() {
-        let results =  managedObjectContext.from(Employee).order(NSSortDescriptor(key: "firstName", ascending: true)).all()
+        let results = managedObjectContext.from(Employee).order(NSSortDescriptor(key: "firstName", ascending: true)).all()
         XCTAssert(results.first!.firstName == "David" && results.last!.firstName == "Lana")
     }
 }

--- a/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
+++ b/CoreDataQueryInterfaceTests/SelectionAndGroupingTests.swift
@@ -29,7 +29,7 @@ class SelectionTests : BaseTestCase {
     
     func testMinimumSalaryGroupedByDepartment() {
         let employee = EmployeeAttribute()
-        let result = try! managedObjectContext.from(Employee).groupBy(employee.department.name).select(employee.department.name, employee.min.salary.named("minSalary")).order(descending: employee.department.name).all()
+        let result =  managedObjectContext.from(Employee).groupBy(employee.department.name).select(employee.department.name, employee.min.salary.named("minSalary")).order(descending: employee.department.name).all()
         let salaries: [String: Int] = result.toDictionary() { ($0["department.name"]! as! String, ($0["minSalary"]! as! NSNumber).integerValue) }
         XCTAssertEqual(salaries["Accounting"]!, 32000)
         XCTAssertEqual(salaries["Engineering"]!, 54000)
@@ -68,17 +68,17 @@ class SelectionTests : BaseTestCase {
     }
     
     func testStringAsSelectionProperty() {
-        let result = try! managedObjectContext.from(Employee).groupBy("lastName").select("lastName").all()
+        let result =  managedObjectContext.from(Employee).groupBy("lastName").select("lastName").all()
         XCTAssertEqual(result.count, 5)
     }
     
     func testMultipleGroupByProperty() {
-        let result = try! managedObjectContext.from(Employee).groupBy({[$0.lastName, $0.department]}).select("lastName", "department").all()
+        let result =  managedObjectContext.from(Employee).groupBy({[$0.lastName, $0.department]}).select("lastName", "department").all()
         XCTAssertEqual(result.count, 13)
     }
     
     func testOrderByNSSortDescriptor() {
-        let results = try! managedObjectContext.from(Employee).order(NSSortDescriptor(key: "firstName", ascending: true)).all()
+        let results =  managedObjectContext.from(Employee).order(NSSortDescriptor(key: "firstName", ascending: true)).all()
         XCTAssert(results.first!.firstName == "David" && results.last!.firstName == "Lana")
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Core Data Query Interface (CDQI) is a type-safe, fluent, intuitive library for w
 The best way to understand the advantages of CDQI is to see an example.
 
 ```swift
-try! managedObjectContext
+managedObjectContext
     .from(Employee)
     .filter{$0.salary > 70000 && $0.department.name == "Engineering"}
     .order(descending: {$0.lastName}, {$0.firstName})
@@ -302,7 +302,7 @@ In this case, since no managed object context has been specified, it will have t
 There are several query execution methods. I'll deal with each in turn, starting with `all`.
 
 ```swift
-try! moc.from(Department).filter {$0.name == "Engineering"}.all()
+moc.from(Department).filter {$0.name == "Engineering"}.all()
 ```
 
 Very simply, this returns all managed objects of the appropriate type—`Department` in this case—which satisfy the query.
@@ -310,7 +310,7 @@ Very simply, this returns all managed objects of the appropriate type—`Departm
 For a query that did not start with a managed object context, it can be passed as the first parameter to `all`.
 
 ```swift
-try! EntityQuery.from(Department).order({$0.name}).all(moc)
+EntityQuery.from(Department).order({$0.name}).all(moc)
 ```
 
 As shown in the example above, all of the query execution methods take an optional `NSManagedObjectContext` as a parameter (though it isn't always the first parameter), so I won't show further examples of that.
@@ -318,13 +318,13 @@ As shown in the example above, all of the query execution methods take an option
 Next up is `count`, which works as advertised:
 
 ```swift
-let departmentCount = try! moc.from(Department).filter{$0.employees.count > 10}.count()
+let departmentCount = moc.from(Department).filter{$0.employees.count > 10}.count()
 ```
 
 The `first` method returns either the first matching result or `nil`.
 
 ```swift
-let department = try! moc.from(Department).first()!
+let department = moc.from(Department).first()!
 ```
 
 Obviously if there are no departments, we'll get a runtime exception, so I don't recommend force-unwrapping the optional returned by `first` unless you're very certain.
@@ -332,7 +332,7 @@ Obviously if there are no departments, we'll get a runtime exception, so I don't
 The `array` query execution method is best demonstrated by example:
 
 ```swift
-let names: [String] = try! moc.from(Department).array {$0.name}
+let names: [String] = moc.from(Department).array {$0.name}
 ```
 
 This returns an array of department names. Because it can only return a _single_ attribute of an entity, any previous `select`s are ignored. You must give the compiler enough type evidence to know what to cast its result to, which is why `[String]` was specified explicitly.
@@ -340,7 +340,7 @@ This returns an array of department names. Because it can only return a _single_
 `value` is to `array` what `first` is to `all`. In other words, it returns the first matching attribute value.
 
 ```swift
-let name: String = try! moc.from(Department).filter({none($0.employees.salary < 40000)}).value({$0.name})!
+let name: String = moc.from(Department).filter({none($0.employees.salary < 40000)}).value({$0.name})!
 ```
 
 Like `first`, `value` returns `nil` if there was no matching value. Like `array`, it supercedes any prior `select`s and requires type evidence to know what to cast its value to.


### PR DESCRIPTION
This pull request is all about test coverage. While the tests are very simple, it's mostly about just expressing every possible use case made possible by the framework's api to make sure they continue to compile forever or until we change our minds. The only tests that failed were using < or > against nil, so those operators and related functions have been removed.

Code coverage gathering is now enabled by default on the scheme. The current coverage is at 93%, up from 70.
